### PR TITLE
Improved UI

### DIFF
--- a/plugin/vim-llm-chat.vim
+++ b/plugin/vim-llm-chat.vim
@@ -1,5 +1,5 @@
-" LLMChat: FZF-based Chat UI for Vim with LLM backend
-" Requires fzf.vim and simonw/llm CLI installed and available in your $PATH
+" LLMChat: A Chat UI for Vim with LLM backend
+" Requires simonw/llm CLI installed and available in your $PATH
 
 if exists('g:loaded_llmchat')
   finish
@@ -9,82 +9,202 @@ let g:loaded_llmchat = 1
 " In-memory chat history (as a List of strings)
 let s:llmchat_history = []
 
-" Write chat history to a temp file, return the filename
-function! s:WriteHistoryToFile()
-  let l:file = '/tmp/llmchat_history_' . printf('%d', localtime()) . '_' . printf('%d', rand())
-  call writefile(s:llmchat_history, l:file)
-  call system('chmod 644 ' . shellescape(l:file))
-  return l:file
+" Call the LLM backend with the given prompt, return the response as string
+
+" Ensure the history buffer exists and return its buffer number
+function! s:EnsureHistoryBuffer()
+  let l:bufnr = bufnr('__LLMChatHistory__')
+  if l:bufnr == -1
+    let l:bufnr = nvim_create_buf(v:false, v:true) " buflisted=false, scratch=true
+    call nvim_buf_set_name(l:bufnr, '__LLMChatHistory__')
+    call setbufvar(l:bufnr, '&buftype', 'nofile')
+    call setbufvar(l:bufnr, '&bufhidden', 'hide')
+    call setbufvar(l:bufnr, '&swapfile', v:false)
+  endif
+  return l:bufnr
 endfunction
 
-" Call the LLM backend with the given prompt, return the response as string
-function! s:AskLLM(prompt)
-  let l:llm_cmd = get(g:, 'llmchat_llm_command', 'llm')
+let s:history_win_id = -1
+let s:input_win_id = -1
+let s:input_bufnr = -1
+let s:is_first_exchange_in_session = 1
+
+" Open the chat windows (history and input)
+function! s:OpenChatWindows()
+  " Calculate window sizes
+  let l:total_height = &lines - &cmdheight - 1 " available height
+  let l:history_height = float2nr(l:total_height * 0.8)
+  let l:input_height = l:total_height - l:history_height -1 " -1 for status line
+
+  if l:input_height < 2
+    let l:input_height = 2
+    let l:history_height = l:total_height - l:input_height - 1
+  endif
+
+  " Ensure history buffer exists
+  let l:history_bufnr = s:EnsureHistoryBuffer()
+
+  " Create history window
+  execute l:history_height . 'new'
+  let s:history_win_id = win_getid()
+  call win_execute(s:history_win_id, 'buffer ' . l:history_bufnr)
+  call setwinvar(s:history_win_id, '&winfixheight', 1)
+  call setwinvar(s:history_win_id, '&readonly', 1)
+  " Set buffer options for history buffer
+  call setbufvar(l:history_bufnr, '&wrap', 1) " Ensure wrap is on for the buffer
+  call setbufvar(l:history_bufnr, '&list', 0) " Disable list characters
+  call setbufvar(l:history_bufnr, '&spell', 0) " Disable spell checking
+  call nvim_buf_set_keymap(l:history_bufnr, 'n', 'q', ':call s:CloseChatWindows()<CR>', {'noremap': v:true, 'silent': v:true})
+
+  " Create input window
+  execute 'new'
+  let s:input_win_id = win_getid()
+  let s:input_bufnr = nvim_create_buf(v:false, v:true) " buflisted=false, scratch=true
+  call nvim_buf_set_name(s:input_bufnr, '__LLMChatInput__')
+  call setbufvar(s:input_bufnr, '&buftype', 'nofile')
+  call setbufvar(s:input_bufnr, '&bufhidden', 'hide')
+  call setbufvar(s:input_bufnr, '&swapfile', v:false)
+  call win_execute(s:input_win_id, 'buffer ' . s:input_bufnr)
+  call setwinvar(s:input_win_id, '&winfixheight', 1)
+  execute 'resize ' . l:input_height
+
+  " Set buffer-local mappings for <CR> and q in the input window
+  if s:input_bufnr != -1
+    call nvim_buf_set_keymap(s:input_bufnr, 'n', '<CR>', ':call s:SubmitInput()<CR>', {'noremap': v:true, 'silent': v:true})
+    call nvim_buf_set_keymap(s:input_bufnr, 'i', '<CR>', '<Esc>:call s:SubmitInput()<CR>', {'noremap': v:true, 'silent': v:true})
+    call nvim_buf_set_keymap(s:input_bufnr, 'n', 'q', ':call s:CloseChatWindows()<CR>', {'noremap': v:true, 'silent': v:true})
+    call setbufvar(s:input_bufnr, '&modifiable', 1) " Ensure buffer is modifiable
+  endif
+
+  " Switch focus to input window and start insert mode
+  call win_gotoid(s:input_win_id)
+  startinsert
+endfunction
+
+" Display g:llmchat_history in the history window
+function! s:DisplayHistory()
+  let l:history_bufnr = s:EnsureHistoryBuffer()
+
+  " Make buffer modifiable to clear and append lines
+  call nvim_buf_set_option(l:history_bufnr, 'modifiable', v:true)
+
+  " Clear the buffer
+  call nvim_buf_set_lines(l:history_bufnr, 0, -1, v:false, [])
+
+  " Append history lines
+  if exists('g:llmchat_history') && !empty(g:llmchat_history)
+    call nvim_buf_set_lines(l:history_bufnr, 0, 0, v:false, g:llmchat_history)
+  endif
+
+  " Make buffer readonly again
+  call nvim_buf_set_option(l:history_bufnr, 'modifiable', v:false)
+
+  " Go to the last line in the history window
+  if s:history_win_id != -1 && win_id2win(s:history_win_id) > 0
+    call win_execute(s:history_win_id, 'normal! G')
+  endif
+endfunction
+
+" Close the chat windows and clean up
+function! s:CloseChatWindows()
+  " Close history window
+  if s:history_win_id != -1 && win_id2win(s:history_win_id) > 0
+    call nvim_win_close(s:history_win_id, v:true) " force close
+  endif
+  let s:history_win_id = -1
+
+  " Close input window and delete its buffer
+  if s:input_win_id != -1 && win_id2win(s:input_win_id) > 0
+    call nvim_win_close(s:input_win_id, v:true) " force close
+  endif
+  let s:input_win_id = -1
+
+  if s:input_bufnr != -1 && bufexists(s:input_bufnr)
+    call nvim_buf_delete(s:input_bufnr, {'force': v:true})
+  endif
+  let s:input_bufnr = -1
+endfunction
+
+" Handle user input submission from the input window
+function! s:SubmitInput()
+  if s:input_bufnr == -1 || !bufexists(s:input_bufnr)
+    return
+  endif
+
+  let l:input_lines = getbufline(s:input_bufnr, 1, '$')
+  let l:userInput = trim(join(l:input_lines, "\n"))
+
+  if !empty(l:userInput)
+    call add(s:llmchat_history, 'You: ' . l:userInput)
+    " Display the "You:" message immediately
+    call s:DisplayHistory() 
+
+    redraw | echo "Waiting for LLM..."
+    let l:llm_output = s:AskLLM(l:userInput, !s:is_first_exchange_in_session)
+    redraw | echo "" " Clear the waiting message
+
+    if !empty(trim(l:llm_output))
+      call add(s:llmchat_history, 'LLM: ' . substitute(l:llm_output, '\n\+$', '', ''))
+      " Only set s:is_first_exchange_in_session to 0 if the command was found and executed.
+      " The specific error message for "command not found" is checked.
+      if stridx(l:llm_output, "Error: llm command not found or not executable:") != 0
+        let s:is_first_exchange_in_session = 0
+      endif
+    else
+      " Handle empty response (which might occur if llm command is not found and returns an empty string somehow, though unlikely with current s:AskLLM)
+      " If AskLLM returns empty, it implies an issue, so don't toggle s:is_first_exchange_in_session.
+    endif
+
+    let g:llmchat_history = s:llmchat_history
+    call s:DisplayHistory() " Display the "LLM:" message
+
+    " Clear the input buffer
+    call nvim_buf_set_lines(s:input_bufnr, 0, -1, v:false, [''])
+  endif
+
+  " Ensure input window is in insert mode and cursor at line 1, column 1
+  if s:input_win_id != -1 && win_id2win(s:input_win_id) > 0
+    call cursor(1, 1) " Position cursor at the beginning of the buffer
+    call win_execute(s:input_win_id, 'startinsert')
+  endif
+endfunction
+
+function! s:AskLLM(prompt, is_follow_up)
+  let l:llm_cmd_base = get(g:, 'llmchat_llm_command', 'llm')
+
+  if !executable(l:llm_cmd_base)
+    return "Error: llm command not found or not executable: " . l:llm_cmd_base
+  endif
+
   let l:model_arg = get(g:, 'llmchat_llm_model_arg', '')
-  let l:cmd = l:llm_cmd
+  let l:cmd = l:llm_cmd_base
+
+  if a:is_follow_up
+    let l:cmd .= ' -c'
+  endif
+
   if !empty(l:model_arg)
     let l:cmd .= ' -m ' . shellescape(l:model_arg)
   endif
-  return system(l:cmd, a:prompt)
+
+  let l:response = system(l:cmd, a:prompt)
+  if v:shell_error != 0
+    let l:response = "LLM Error: " . l:response
+  endif
+  return l:response
 endfunction
 
-" FZF chat main entry point
+" Main entry point for LLMChat
 function! LLMChat()
+  let s:is_first_exchange_in_session = 1
   " Use global so user can keep chat between invocations
   if exists('g:llmchat_history')
     let s:llmchat_history = g:llmchat_history
   else
     let s:llmchat_history = []
   endif
-  call s:LLMChatFZF()
-endfunction
-
-" Main FZF chat loop (called after each turn)
-function! s:LLMChatFZF()
-  let l:history_file = s:WriteHistoryToFile()
-  let l:opts = [
-        \ '--prompt=You: ',
-        \ '--layout=reverse',
-        \ '--info=inline',
-        \ '--preview', 'cat ' . shellescape(l:history_file),
-        \ '--preview-window', 'up:70%:wrap',
-        \ '--no-sort',
-        \ '--no-multi',
-        \ '--bind', 'enter:accept,shift-up:preview-up,shift-down:preview-down',
-        \ '--bind', 'ctrl-u:preview-page-up,ctrl-d:preview-page-down',
-        \ '--print-query'
-        \ ]
-  let l:spec = {
-        \ 'source': [' '],
-        \ 'sink*': function('s:OnFZFChatSend'),
-        \ 'options': l:opts,
-        \ 'window': {
-        \   'width': 120,
-        \   'height': &lines - 2,
-        \   'xoffset': 1,
-        \   'yoffset': 0,
-        \   'highlight': 'Normal',
-        \   'border': 'none'
-        \ }}
-  call fzf#run(l:spec)
-endfunction
-
-" Handler: user submits message via FZF
-function! s:OnFZFChatSend(lines)
-  if len(a:lines) == 0
-    return
-  endif
-
-  " First line is the user's typed input (from --print-query)
-  let l:input = a:lines[0]
-  if !empty(trim(l:input))
-    call add(s:llmchat_history, 'You: ' . l:input)
-    redraw | echo "Waiting for LLM..."
-    let l:response = s:AskLLM(l:input)
-    call add(s:llmchat_history, 'LLM: ' . substitute(l:response, '\n\+$', '', ''))
-    let g:llmchat_history = s:llmchat_history
-    call s:LLMChatFZF()
-  endif
+  call s:OpenChatWindows()
+  call s:DisplayHistory()
 endfunction
 
 " Command to start chat

--- a/plugin/vim-llm-chat.vim
+++ b/plugin/vim-llm-chat.vim
@@ -48,7 +48,8 @@ function! s:OpenChatWindows()
   " Create history window
   execute l:history_height . 'new'
   let s:history_win_id = winnr() " Get current window NUMBER
-  execute 'buffer ' . l:history_bufnr " Associate buffer with this new window
+  " Associate buffer with this new window
+  execute 'buffer ' . l:history_bufnr 
   call setwinvar(s:history_win_id, '&winfixheight', 1)
   call setbufvar(l:history_bufnr, '&readonly', 1)
   call setbufvar(l:history_bufnr, '&wrap', 1)
@@ -57,19 +58,23 @@ function! s:OpenChatWindows()
 
   " Set keymap for history window
   let l:original_winnr = winnr()
-  execute s:history_win_id . "wincmd w" " Focus history window
+  " Focus history window
+  execute s:history_win_id . "wincmd w" 
   execute 'nnoremap <buffer><silent> q :call <SID>CloseChatWindows()<CR>'
-  execute l:original_winnr . "wincmd w" " Focus original window
+  " Focus original window
+  execute l:original_winnr . "wincmd w" 
 
   " Create input window
-  execute 'new' " This creates a new window and makes it current
+  " This creates a new window and makes it current
+  execute 'new' 
   let s:input_win_id = winnr() " Get current window NUMBER for the new input window
   let s:input_bufname = '__LLMChatInput__' " Name for the input buffer
   let s:input_bufnr = bufnr(s:input_bufname)
   if s:input_bufnr == -1 || !bufexists(s:input_bufnr)
     let s:input_bufnr = bufadd(s:input_bufname)
   endif
-  execute 'buffer ' . s:input_bufnr " Associate buffer with the new input window
+  " Associate buffer with the new input window
+  execute 'buffer ' . s:input_bufnr 
   call setbufvar(s:input_bufnr, '&buftype', 'nofile')
   call setbufvar(s:input_bufnr, '&bufhidden', 'hide')
   call setbufvar(s:input_bufnr, '&swapfile', 0)
@@ -81,14 +86,17 @@ function! s:OpenChatWindows()
 
   " Set buffer-local mappings for <CR> and q in the input window
   let l:original_winnr_for_input_map = winnr()
-  execute s:input_win_id . "wincmd w" " Focus input window
+  " Focus input window
+  execute s:input_win_id . "wincmd w" 
   execute 'nnoremap <buffer><silent> <CR> :<C-U>call <SID>SubmitInput()<CR>'
   execute 'inoremap <buffer><silent> <CR> <Esc>:<C-U>call <SID>SubmitInput()<CR>'
   execute 'nnoremap <buffer><silent> q :<C-U>call <SID>CloseChatWindows()<CR>'
-  execute l:original_winnr_for_input_map . "wincmd w" " Focus original window
+  " Focus original window
+  execute l:original_winnr_for_input_map . "wincmd w" 
 
   " Switch focus to input window and start insert mode
-  execute s:input_win_id . "wincmd w" " Focus input window
+  " Focus input window
+  execute s:input_win_id . "wincmd w" 
   startinsert
 endfunction
 
@@ -114,9 +122,11 @@ function! s:DisplayHistory()
   " Go to the last line in the history window
   if s:history_win_id > 0 && winbufnr(s:history_win_id) > 0 " Check if window number is valid
     let l:original_winnr_hist_scroll = winnr()
-    execute s:history_win_id . "wincmd w" " Focus history window
+    " Focus history window
+    execute s:history_win_id . "wincmd w" 
     normal! G
-    execute l:original_winnr_hist_scroll . "wincmd w" " Focus original window
+    " Focus original window
+    execute l:original_winnr_hist_scroll . "wincmd w" 
   endif
 endfunction
 
@@ -183,7 +193,7 @@ function! s:SubmitInput()
     call setbufvar(s:input_bufnr, '&modifiable', 1) " Ensure it's modifiable before clearing
     call deletebufline(s:input_bufnr, 1, line('$')) " Clear all lines
     call appendbufline(s:input_bufnr, 0, [''])      " Add a single empty line to start
-    " call setbufvar(s:input_bufnr, '&modifiable', 1) " Buffer should remain modifiable
+    call setbufvar(s:input_bufnr, '&modifiable', 1) " Buffer should remain modifiable
   endif
 
   " Ensure input window is in insert mode and cursor at line 1, column 1


### PR DESCRIPTION
Jules's attempt to remove the fzf dependency.

Original problem: fzf usage means that user can not return to the original file without closing the fzf view (and presently, no way to return to prior fzf view).

It's possible that this is recoverable with some work, but Jules's initial output doesn't really work as desired. Opening PR for historical purposes